### PR TITLE
Rule updates for clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+# About
+The Software Engineering Community is an X Community geared towards software engineers to discuss all technical topics that reside within the software engineering field. This document states and summarizes the rules for the community to ensure that the discussions remain on-topic and result in a pleasant experience within the community.
+
+Join here: [Software Engineering (x.com)](https://twitter.com/i/communities/1699807431709041070)
+
 # Rules
 
 If you think something needs to be re-defined, please forks this repo and send a PR and we will review it. There is a current restriction of 160 characters so take that in mind!
@@ -12,10 +17,10 @@ If you think something needs to be re-defined, please forks this repo and send a
 
 5. **No general career advice.** - Any career advice post must contain questions and/or discussions that notably benefit from the participation of aspiring or professional software engineers.
 
-6. **No spamming.** - Don't spam with the same content over and over. Also don't respond to a post with a quote in a new post or use the hashtag #news. Spam will result in ban.
+6. **No spamming.** - Don't spam the same content repeatedly or respond to a post with a quote in a new post or use the hashtag #news. Spam will result in ban. Limit to 2 hashtags.
 
 7. **No memes.** - Although we love memes, we want to have a community of serious discourse. Find another appropriate community for memes.
 
 8. **No posts in languages other than English.** - The only language that should be used here is English. And that includes links to resources as well.
 
-9. **No low-effort posts.** - For example, no posts with bare links/reposts without containing any additional and insightful comment/description.
+9. **No low-effort posts.** - For example, no posts with bare links/reposts without containing any additional and insightful comment/description. Single-line posts that don't encourage discussion are also considered low-effort.

--- a/README.md
+++ b/README.md
@@ -23,4 +23,4 @@ If you think something needs to be re-defined, please forks this repo and send a
 
 8. **No posts in languages other than English.** - The only language that should be used here is English. And that includes links to resources as well.
 
-9. **No low-effort posts.** - For example, no posts with bare links/reposts without containing any additional and insightful comment/description. Single-line posts that don't encourage discussion are also considered low-effort.
+9. **No low-effort posts.** - For example, no posts with bare links/reposts without added insightful comment/description. Single-line posts not encouraging discussion are also low-effort.


### PR DESCRIPTION
Added rule updates for clarity and general readme improvements.

Bulletlist of exact changes:
- Added community desc to top of readme
- Added link to x community
- Added clarifying language to the spamming rule to indicate the use of hashtags
- Added mention of single-line posts to fall under the "low-effort" designation