### PR TITLE
Update rule #10 to apply to very short posts

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,4 +23,4 @@ If you think something needs to be re-defined, please forks this repo and send a
 
 8. **No posts in languages other than English.** - The only language that should be used here is English. And that includes links to resources as well.
 
-9. **No low-effort posts.** - For example, no posts with bare links/reposts without added insightful comment/description. Single-line posts not encouraging discussion are also low-effort.
+9. **No low-effort posts.** - For example, no posts with bare links/reposts without added insightful comment/description. Very short posts not encouraging discussion are also low-effort.


### PR DESCRIPTION
By saying _very short_ posts instead of _single-line_ posts the rule will also cover very short posts that span multiple lines.